### PR TITLE
New feature: "unique-id".

### DIFF
--- a/docs/words/expose.md
+++ b/docs/words/expose.md
@@ -2,7 +2,7 @@
 
 ### `forth`
 
-Thes words are in `forth`.
+These words are in `forth`.
 
 ##### `state`
 
@@ -156,3 +156,14 @@ Get the PENDSV-HANDLER-HOOK variable address
 ##### `systick-handler-hook`
 
 Get the SYSTICK-HANDLER-HOOK variable address
+
+## RP2040 Word
+
+### `forth`
+
+This word is in `forth`.
+
+##### `unique-id`
+( -- d )
+
+Returns the 64-bit board unique ID value, as a double number.

--- a/src/rp2040/variables.s
+++ b/src/rp2040/variables.s
@@ -31,3 +31,5 @@
 	allot hold_core, 4 * cpu_count
 
 	allot sysclk, 4
+
+	allot pico_uuid, 12


### PR DESCRIPTION
This returns the board unique ID on Raspberry Pico boards, as a 64 bit value.

See https://github.com/tabemann/zeptoforth/discussions/45