### PR TITLE
Two *task* documentation issues

### DIFF
--- a/docs/words/task.md
+++ b/docs/words/task.md
@@ -84,9 +84,9 @@ Configure notification for a task, with *notify-count* being the number of suppo
 To reinitialize existing tasks, one executes:
 
 ##### `init-task`
-( xn...x0 count xt task -- )
+( xn...x0 count xt task core -- )
 
-These tasks may be in any state, including being terminated. *xn* through *x0* are parameters to pass to the *xt* when executed.
+These tasks may be in any state, including being terminated. *xn* through *x0* are parameters to pass to the *xt* when executed.  It will execute on *core*.
 
 New tasks do not execute right away, rather to enable their execution, one executes:
 

--- a/src/common/forth/task.fs
+++ b/src/common/forth/task.fs
@@ -53,21 +53,6 @@ begin-module task
     \ The maximum task priority
     $7FFF constant max-priority
 
-    \ Task has not terminated
-    0 constant not-terminated
-
-    \ Task has terminated normally
-    1 constant terminated-normally
-
-    \ Task has been killed
-    2 constant terminated-killed
-
-    \ Task has terminated due to a hardware exception
-    3 constant terminated-crashed
-
-    \ Task has terminated due to a stack overflow
-    4 constant terminated-overflowed
-
     \ Task guard value
     $DEADCAFE constant task-guard-value
     
@@ -282,6 +267,21 @@ begin-module task
   \ No timeout
   $80000000 constant no-timeout
   
+  \ Task has not terminated
+  0 constant not-terminated
+
+  \ Task has terminated normally
+  1 constant terminated-normally
+
+  \ Task has been killed
+  2 constant terminated-killed
+
+  \ Task has terminated due to a hardware exception
+  3 constant terminated-crashed
+
+  \ Task has terminated due to a stack overflow
+  4 constant terminated-overflowed
+
   \ Attempted to use a terminated task
   : x-terminated ( -- ) ." task has been terminated" cr ;
 


### PR DESCRIPTION
1. Document the *core* argument of *init-task*.
2. Move the standard task exit codes to *task* since they are documented.