### PR TITLE
Two PIO updates

### DIFF
--- a/docs/words/pio.md
+++ b/docs/words/pio.md
@@ -469,7 +469,7 @@ PIO SET instruction with delay or side-set. Set *destination* to *data*, which i
 
 These words are useful only within the context of a `:pio` program definition.  They are in the `pioasm` word list, which is automatically imported by `:pio` and unimported by `;pio`.
 
-##### `mark>`
+##### `mark<`
 ( -- jmp-mark )
 
 Mark a backward destination.

--- a/test/rp2040/pio_blinker.fs
+++ b/test/rp2040/pio_blinker.fs
@@ -24,22 +24,24 @@ continue-module forth
   pio import
 
   \ The initial setup
-  create pio-init
-  1 SET_PINDIRS set,
-  0 SET_PINS set,
+  :pio pio-init
+    1 SET_PINDIRS set,
+    0 SET_PINS set,
+  ;pio
   
   \ The PIO code
-  create pio-code
-  1 19 SET_PINS set+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  0 19 SET_PINS set+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
-  MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+  :pio pio-code
+    1 19 SET_PINS set+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    0 19 SET_PINS set+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+    MOV_SRC_X 19 MOV_OP_NONE MOV_DEST_X mov+,
+  ;pio
   
   \ Init blinker
   : init-blinker ( -- )
@@ -48,11 +50,9 @@ continue-module forth
     0 62500 0 PIO0 sm-clkdiv!
     25 1 PIO0 pins-pio-alternate
     25 1 0 PIO0 sm-set-pins!
-    0 9 0 PIO0 sm-wrap!
     on 0 PIO0 sm-out-sticky!
-    pio-init 2 0 PIO0 sm-instr!
-    pio-code 10 PIO0 pio-instr-mem!
-    0 0 PIO0 sm-addr!
+    pio-init p-prog 0 PIO0 sm-instr!
+    0 PIO0 pio-code 0 setup-prog
     %0001 PIO0 sm-enable
   ;
 

--- a/test/rp2040/pio_blinker_1.fs
+++ b/test/rp2040/pio_blinker_1.fs
@@ -25,21 +25,25 @@ continue-module forth
   pio import
 
   \ The initial setup
-  create pio-init
-  1 SET_PINDIRS set,
-  0 SET_PINS set,
+  :pio pio-init
+    1 SET_PINDIRS set,
+    0 SET_PINS set,
+  ;pio
   
   \ The PIO code
-  create pio-code
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  1 SET_PINS set,
-  3 COND_X1- jmp,
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  0 SET_PINS set,
-  7 COND_X1- jmp,
-
+  :pio pio-code
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    1 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    0 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+  ;pio
+  
   \ The blinker rate
   variable blinker-vary
 
@@ -55,12 +59,11 @@ continue-module forth
     %0001 PIO0 sm-disable
     %0001 PIO0 sm-restart
     0 62500 0 PIO0 sm-clkdiv!
-    25 1 PI0 pins-pio-alternate
+    25 1 PIO0 pins-pio-alternate
     25 1 0 PIO0 sm-set-pins!
-    0 7 0 PIO0 sm-wrap!
     on 0 PIO0 sm-out-sticky!
-    pio-init 2 0 PIO0 sm-instr!
-    pio-code 8 PIO0 pio-instr-mem!
+    pio-init p-prog 0 PIO0 sm-instr!
+    0 PIO0 pio-code 0 setup-prog
     0 0 PIO0 sm-addr!
     blinker-vary @ 0 PIO0 sm-txf!
     ['] handle-pio PIO0_IRQ0 16 + vector!

--- a/test/rp2040/pio_fade_blinker.fs
+++ b/test/rp2040/pio_fade_blinker.fs
@@ -26,21 +26,25 @@ continue-module forth
   systick import
 
   \ The initial setup
-  create pio-init
-  1 SET_PINDIRS set,
-  0 SET_PINS set,
+  :pio pio-init
+    1 SET_PINDIRS set,
+    0 SET_PINS set,
+  ;pio
   
   \ The PIO code
-  create pio-code
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  1 SET_PINS set,
-  3 COND_X1- jmp,
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  0 SET_PINS set,
-  7 COND_X1- jmp,
-
+  :pio pio-code
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    1 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    0 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+  ;pio
+  
   \ The blinker state
   variable blinker-state
 
@@ -101,10 +105,9 @@ continue-module forth
     0 758 0 PIO0 sm-clkdiv!
     25 1 PIO0 pins-pio-alternate
     25 1 0 PIO0 sm-set-pins!
-    0 7 0 PIO0 sm-wrap!
     on 0 PIO0 sm-out-sticky!
-    pio-init 2 0 PIO0 sm-instr!
-    pio-code 8 PIO0 pio-instr-mem!
+    pio-init p-prog 0 PIO0 sm-instr!
+    0 PIO0 pio-code 0 setup-prog
     0 0 PIO0 sm-addr!
     blinker-shade @ 0 PIO0 sm-txf!
     ['] handle-pio PIO0_IRQ0 16 + vector!

--- a/test/rp2040/pio_log_fade_blinker.fs
+++ b/test/rp2040/pio_log_fade_blinker.fs
@@ -26,21 +26,25 @@ continue-module forth
   systick import
 
   \ The initial setup
-  create pio-init
-  1 SET_PINDIRS set,
-  0 SET_PINS set,
+  :pio pio-init
+    1 SET_PINDIRS set,
+    0 SET_PINS set,
+  ;pio
   
   \ The PIO code
-  create pio-code
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  1 SET_PINS set,
-  3 COND_X1- jmp,
-  PULL_BLOCK PULL_NOT_EMPTY pull,
-  32 OUT_X out,
-  0 SET_PINS set,
-  7 COND_X1- jmp,
-
+  :pio pio-code
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    1 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+    PULL_BLOCK PULL_NOT_EMPTY pull,
+    32 OUT_X out,
+    0 SET_PINS set,
+    mark<
+    COND_X1- jmp<
+  ;pio
+  
   \ The blinker state
   variable blinker-state
 
@@ -113,11 +117,9 @@ continue-module forth
     0 758 0 PIO0 sm-clkdiv!
     25 1 PIO0 pins-pio-alternate
     25 1 0 PIO0 sm-set-pins!
-    0 7 0 PIO0 sm-wrap!
     on 0 PIO0 sm-out-sticky!
-    pio-init 2 0 PIO0 sm-instr!
-    pio-code 8 PIO0 pio-instr-mem!
-    0 0 PIO0 sm-addr!
+    pio-init p-prog 0 PIO0 sm-instr!
+    0 PIO0 pio-code 0 setup-prog
     blinker-shade @ 0 PIO0 sm-txf!
     ['] handle-pio PIO0_IRQ0 16 + vector!
     0 INT_SM_TXNFULL IRQ0 PIO0 pio-interrupt-enable


### PR DESCRIPTION
Convert the PIO "blinker" examples to new style.
Fix a typo in the PIO documentation.