### PR TITLE
Add DMA timers allocate/free to dma-pool module.

### DIFF
--- a/docs/words/dma.md
+++ b/docs/words/dma.md
@@ -242,6 +242,16 @@ No DMA channels available exception.
 
 DMA channel is already free.
 
+##### `x-no-dma-timers-available`
+( -- )
+
+No DMA timers available exception.
+
+##### `x-dma-timer-already-free`
+( -- )
+
+DMA timer is already free.
+
 ##### `allocate-dma`
 ( -- channel )
 
@@ -251,3 +261,13 @@ Allocate a DMA channel.
 ( channel -- )
 
 Free a DMA channel
+
+##### `allocate-timer`
+( -- timer )
+
+Allocate a DMA timer.
+
+##### `free-timer`
+( timer -- )
+
+Free a DMA timer

--- a/src/rp2040/forth/dma.fs
+++ b/src/rp2040/forth/dma.fs
@@ -113,7 +113,7 @@ begin-module dma
 
     \ Validate timer
     : validate-timer ( timer -- )
-      timer u< averts x-out-of-range-timer
+      timer-count u< averts x-out-of-range-timer
     ;
     
     \ Get bits for transfer size


### PR DESCRIPTION
This adds `allocate-timer` and `free-timer` words to `dma-pool` to manage the pool of DMA timers.  It also fixes a bug in `dma-internal::validate-timer`.