### PR TITLE
cyw43: don't use pio-addr argument

### DIFF
--- a/docs/extra/cyw43.md
+++ b/docs/extra/cyw43.md
@@ -20,7 +20,9 @@ The `<cyw43-control>` class has the constructor:
 ##### `new`
 ( D: mac-addr clm-addr clm-bytes fw-addr fw-bytes pwr clk dio cs pio-addr sm pio -- )
 
-This instantiates a `<cyw43-control>` instance to use the MAC address *mac-addr* (which if `default-mac-addr` indicates that the default MAC address is to be used), CLM firmware of *clm-bytes* at *clm-addr*, main firmware of *fw-bytes* at *fw-addr*, *pwr*, *clk*, *dio*, and *cs* GPIO pins for communication with the CYW43xxx, and PIO instruction base address *pio-addr*, PIO state machine index *sm*, and PIO instance *pio* (`pio::PIO0` or `pio::PIO1`).
+This instantiates a `<cyw43-control>` instance to use the MAC address *mac-addr* (which if `default-mac-addr` indicates that the default MAC address is to be used), CLM firmware of *clm-bytes* at *clm-addr*, main firmware of *fw-bytes* at *fw-addr*, *pwr*, *clk*, *dio*, and *cs* GPIO pins for communication with the CYW43xxx, and PIO state machine index *sm*, and PIO instance *pio* (`pio::PIO0` or `pio::PIO1`).
+
+Note that *pio-addr* is no longer used, but it is retained in the argument list for backward compatibility.  The CYW43xxx driver uses `alloc-piomem` to obtain space for its PIO program.  If you need to place other PIO programs in the same PIO instance, you need to use `alloc-piomem` for those as well to avoid PIO memory addressing conflicts.
 
 The `<cyw43-control>` class has the following methods:
       

--- a/extra/rp2040/cyw43/cyw43_bus.fs
+++ b/extra/rp2040/cyw43/cyw43_bus.fs
@@ -153,7 +153,7 @@ begin-module cyw43-bus
   <cyw43-bus> begin-implement
 
     \ The constructor
-    :noname { pwr clk dio cs pio-addr sm pio self -- }
+    :noname { pwr clk dio cs sm pio self -- }
       
       \ Initialize the superclass
       self <object>->new
@@ -164,7 +164,7 @@ begin-module cyw43-bus
       $AAAAAAAA self cyw43-bp-window !
 
       \ Instantiate the SPI interface
-      clk dio cs pio-addr sm pio <cyw43-spi> self cyw43-spi init-object
+      clk dio cs sm pio <cyw43-spi> self cyw43-spi init-object
       
     ; define new
 

--- a/extra/rp2040/cyw43/cyw43_runner.fs
+++ b/extra/rp2040/cyw43/cyw43_runner.fs
@@ -503,7 +503,9 @@ begin-module cyw43-runner
   \ Implement the CYW43 runner class
   <cyw43-runner> begin-implement
 
-    \ The constructor
+    \ The constructor.  Note that pio-addr is no longer used but it's
+    \ included in the argument list because it comes that way from
+    \ the outside.
     :noname { fw-addr fw-bytes pwr clk dio cs pio-addr sm pio self -- }
 
       \ Initialize the superclass
@@ -519,7 +521,7 @@ begin-module cyw43-runner
       event-message-size event-count self cyw43-event-chan init-chan
       
       \ Instantiate the bus
-      pwr clk dio cs pio-addr sm pio <cyw43-bus> self cyw43-bus init-object
+      pwr clk dio cs sm pio <cyw43-bus> self cyw43-bus init-object
       
       \ Instantiate the log
       <cyw43-log> self cyw43-log init-object

--- a/extra/rp2040/cyw43/cyw43_spi.fs
+++ b/extra/rp2040/cyw43/cyw43_spi.fs
@@ -160,7 +160,7 @@ begin-module cyw43-spi
   <cyw43-spi> begin-implement
 
     \ Constructor
-    :noname { clk dio cs pio-addr sm pio self -- }
+    :noname { clk dio cs sm pio self -- }
 
       \ Initialize the superclass
       self <object>->new
@@ -171,7 +171,9 @@ begin-module cyw43-spi
       dio self cyw43-dio !
       clk self cyw43-clk !
       cs self cyw43-cs !
-      pio-addr self cyw43-pio-addr !
+
+      \ Allocate space for the PIO program.
+      pio cyw43-pio-program p-size alloc-piomem self cyw43-pio-addr !
 
       \ Allocate our DMA channel
       allocate-dma self cyw43-dma-channel !
@@ -223,9 +225,8 @@ begin-module cyw43-spi
       sm bit pio sm-disable
 
       \ Set up the PIO program
-      pio cyw43-pio-program p-size alloc-piomem { base-addr }
-      sm pio cyw43-pio-program base-addr setup-prog
-      base-addr sm pio sm-addr!
+      sm pio cyw43-pio-program pio-addr setup-prog
+      pio-addr sm pio sm-addr!
 
       \ Configure the pins to be PIO output, input, set, and sidset pins
       dio 1 pio pins-pio-alternate


### PR DESCRIPTION
Also update the documentation to mention that other users of the same PIO need to use alloc-piomem to avoid conflicts.