### PR TITLE
Fix a typo in the constructor for <simple-net>

### DIFF
--- a/extra/rp_common/net/simple_net.fs
+++ b/extra/rp_common/net/simple_net.fs
@@ -88,7 +88,7 @@ begin-module simple-net
 
     \ Constructor.  
     :noname
-      { self -- )
+      { self -- }
       self <object>->new
 
       false self endpoint-process-started? !


### PR DESCRIPTION
I wonder if it would be useful for the `{` processing to give a warning if it sees `)`.