### PR TITLE
RP2350 partition support (for UF2 Loader compatibility)

### DIFF
--- a/src/common/forth/float32.fs
+++ b/src/common/forth/float32.fs
@@ -631,8 +631,8 @@ begin-module float32
     
     \ Enable floating point
     : enable-float ( -- )
+      FPCCR_ASPEN_LSPEN_BITS FPCCR bic! \ if the FPU is already enabled, this will not cause a fault
       CPACR_FPU_BITS CPACR bit@ not if
-        FPCCR_ASPEN_LSPEN_BITS FPCCR bic!
         CPACR_FPU_BITS CPACR bis!
       then
     ;

--- a/src/rp2350/flashrom.s
+++ b/src/rp2350/flashrom.s
@@ -32,12 +32,14 @@
         .equ XIP_CTRL_EN_SECURE, 0x00000001
         
 	.equ XIP_QMI_BASE, 0x400D0000
+	.equ XIP_QMI_ATRANS0_OFFSET, 0x34
 
         .equ TIMER_BASE, 0x400B0000
         .equ TIMERAWL, TIMER_BASE + 0x28
 
         .equ RESET_TIME_US, 40
         
+	.equ FLASH_BASE, 0x10000000
 	.equ RAM_BASE, 0x20000000
 	.equ FLASH_IMAGE_BASE, 0x10001000
 	.equ IMAGE_SIZE, 0x8000
@@ -287,6 +289,14 @@ _init_flash:
 
         push_tos
 	movs tos, r0
+
+	@ calculate start of partition offset in flash
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+	subs tos, tos, r0
         push_tos
 
 @        push_tos
@@ -298,8 +308,9 @@ _init_flash:
 @        push_tos
 @        bl _h_8
 
-        ldr tos, =flash_dict_end - flash_start
-	bl _erase_range
+		ldr tos, =flash_dict_end
+		subs tos, tos, r0
+		bl _erase_range
 
         cpsie i
         bl _release_core
@@ -736,7 +747,14 @@ _erase_qspi_sector:
 	dsb
 	isb
 	bl _exit_xip
-	ldr r0, =flash_start
+
+	@ calculate start of partition offset in flash
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+
 	subs tos, r0
 	ldr r0, =0xFFFF
 	bics tos, r0
@@ -759,7 +777,14 @@ _erase_qspi_4k_sector:
 	dsb
 	isb
 	bl _exit_xip
-	ldr r0, =flash_start
+
+	@ calculate start of partition offset in flash
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+	
 	subs tos, r0
 	ldr r0, =0xFFF
 	bics tos, r0
@@ -794,7 +819,19 @@ _erase_range:
 	ldr r2, =0xFFFF
 	tst r1, r2
 	bne 3f
-        ldr r2, =flash_dict_main_end - flash_start
+
+	@ calculate start of partition offset in flash
+	push { r0 }
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+	
+		ldr r2, =flash_dict_main_end
+		subs r2, r2, r0
+		pop { r0 }
+
         cmp r1, r2
         bhs 3f
 	push_tos
@@ -843,10 +880,17 @@ _erase_range:
 	define_internal_word "erase-after", visible_flag
 _erase_after:
 	push {lr}
-	ldr r0, =flash_start
+	@ calculate start of partition offset in flash
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+
 	subs tos, r0
         push_tos
-        ldr tos, =flash_main_end - flash_start
+        ldr tos, =flash_main_end
+		subs tos, tos, r0
 	bl _erase_range
         ldr r0, =reboot_hook
         ldr r1, =_do_nothing
@@ -860,10 +904,18 @@ _erase_after:
 	define_internal_word "erase-dict-after", visible_flag
 _erase_dict_after:
 	push {lr}
-	ldr r0, =flash_start
+
+	@ calculate start of partition offset in flash
+	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r0, [r0]
+	ubfx r0, r0, #0, #12
+	lsls r0, #12
+	rsb r0, r0, #FLASH_BASE
+
 	subs tos, r0
         push_tos
-        ldr tos, =flash_main_end - flash_start
+        ldr tos, =flash_main_end
+		subs tos, tos, r0
 	bl _erase_range
         ldr r0, =reboot_hook
         ldr r1, =_do_nothing
@@ -951,7 +1003,14 @@ _init_flash_write:
 	bl _exit_xip
 	bl _enable_flash_cmd
 	bl _enable_flash_write
-	ldr r1, =flash_start
+	
+	@ calculate start of partition offset in flash
+	ldr r1, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r1, [r1]
+	ubfx r1, r1, #0, #12
+	lsls r1, #12
+	rsb r1, r1, #FLASH_BASE
+
 	subs tos, r1
 	push_tos
 	ldr tos, =CMD_PAGE_PROGRAM
@@ -1029,7 +1088,14 @@ _store_mass_qspi:
 	bl _enable_flash_cmd
 	movs r0, tos
 	pull_tos
-	ldr r1, =flash_start
+
+	@ calculate start of partition offset in flash
+	ldr r1, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
+	ldr r1, [r1]
+	ubfx r1, r1, #0, #12
+	lsls r1, #12
+	rsb r1, r1, #FLASH_BASE
+
 	subs r0, r1
 	movs r1, tos
 	pull_tos

--- a/src/rp2350/flashrom.s
+++ b/src/rp2350/flashrom.s
@@ -39,7 +39,6 @@
 
         .equ RESET_TIME_US, 40
         
-	.equ FLASH_BASE, 0x10000000
 	.equ RAM_BASE, 0x20000000
 	.equ FLASH_IMAGE_BASE, 0x10001000
 	.equ IMAGE_SIZE, 0x8000
@@ -291,11 +290,12 @@ _init_flash:
 	movs tos, r0
 
 	@ calculate start of partition offset in flash
+	push { r0 }
 	ldr r0, =(XIP_QMI_BASE + XIP_QMI_ATRANS0_OFFSET)
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 	subs tos, tos, r0
         push_tos
 
@@ -310,6 +310,7 @@ _init_flash:
 
 		ldr tos, =flash_dict_end
 		subs tos, tos, r0
+		pop { r0 }
 		bl _erase_range
 
         cpsie i
@@ -753,7 +754,7 @@ _erase_qspi_sector:
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 
 	subs tos, r0
 	ldr r0, =0xFFFF
@@ -783,7 +784,7 @@ _erase_qspi_4k_sector:
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 	
 	subs tos, r0
 	ldr r0, =0xFFF
@@ -826,7 +827,7 @@ _erase_range:
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 	
 		ldr r2, =flash_dict_main_end
 		subs r2, r2, r0
@@ -885,7 +886,7 @@ _erase_after:
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 
 	subs tos, r0
         push_tos
@@ -910,7 +911,7 @@ _erase_dict_after:
 	ldr r0, [r0]
 	ubfx r0, r0, #0, #12
 	lsls r0, #12
-	rsb r0, r0, #FLASH_BASE
+	rsb r0, r0, #flash_start
 
 	subs tos, r0
         push_tos
@@ -1009,7 +1010,7 @@ _init_flash_write:
 	ldr r1, [r1]
 	ubfx r1, r1, #0, #12
 	lsls r1, #12
-	rsb r1, r1, #FLASH_BASE
+	rsb r1, r1, #flash_start
 
 	subs tos, r1
 	push_tos
@@ -1094,7 +1095,7 @@ _store_mass_qspi:
 	ldr r1, [r1]
 	ubfx r1, r1, #0, #12
 	lsls r1, #12
-	rsb r1, r1, #FLASH_BASE
+	rsb r1, r1, #flash_start
 
 	subs r0, r1
 	movs r1, tos

--- a/src/rp2350/forth/qspi.fs
+++ b/src/rp2350/forth/qspi.fs
@@ -29,12 +29,22 @@ begin-module qspi
   
     \ Quad SPI map base
     $10000000 constant QUADSPI_Map_Base
-    
-    \ Hidden QSPI size
-    $200000 constant QUADSPI_Hidden_Size
 
-    \ Total QSPI size
-    $400000 constant QUADSPI_Size
+    $200000 constant QUADSPI_Usable_Hidden_Size
+    
+    \ Hidden QSPI size (rounded up to nearest 64k sector size if ATRANS0 mapping is used)
+    $400D0034 @ $FFF and 4096 *   \ ADTRANS0 physical address (partition mapping)
+    $FFFF + $FFFF invert and      \ align up to nearest 64k sector
+    QUADSPI_Usable_Hidden_Size +  
+    $400D0034 @ $FFF and 4096 * - \ and subtract the ATRANS0 mapping so that the qspi area starts at 64k boundary after the hidden area
+     constant QUADSPI_Hidden_Size
+
+    \ Total QSPI size (respecting possible ATRANS0 mapping and aligning to 64k sector size)
+    \ Attention: does not check the partition table if there is another partition after the current one or ATRANS Size Bits
+    $400000 
+      $400D0034 @ $FFF and 4096 * \ ADTRANS0 physical address (partition mapping)
+      $FFFF + $FFFF invert and    \ align up to nearest 64k sector
+    - constant QUADSPI_Size
 
   end-module> import
     
@@ -55,8 +65,8 @@ begin-module qspi
   \ Get the base usable Quad SPI address
   : qspi-base ( -- addr ) QUADSPI_Map_Base QUADSPI_Hidden_Size + ;
 
-  \ Get the usable Quad SPI flash size
-  : qspi-size ( -- bytes ) QUADSPI_Size QUADSPI_Hidden_Size - ;
+  \ Get the usable Quad SPI flash size reduced by the hidden area and taking ATRANS0 (partition) mapping into account
+  : qspi-size ( -- bytes ) QUADSPI_Size QUADSPI_Usable_Hidden_Size - ;
 
   \ Bulk erase QSPI
   : erase-qspi-bulk ( -- )

--- a/src/rp2350/forth/qspi.fs
+++ b/src/rp2350/forth/qspi.fs
@@ -32,18 +32,21 @@ begin-module qspi
 
     $200000 constant QUADSPI_Usable_Hidden_Size
     
+    \ flash address translation register
+    $400D0034 constant QMI_ATRANS0
+    
     \ Hidden QSPI size (rounded up to nearest 64k sector size if ATRANS0 mapping is used)
-    $400D0034 @ $FFF and 4096 *   \ ADTRANS0 physical address (partition mapping)
-    $FFFF + $FFFF invert and      \ align up to nearest 64k sector
+    QMI_ATRANS0 @ $FFF and 4096 *   \ ATRANS0 physical address (partition mapping)
+    $FFFF + $FFFF invert and        \ align up to nearest 64k sector
     QUADSPI_Usable_Hidden_Size +  
-    $400D0034 @ $FFF and 4096 * - \ and subtract the ATRANS0 mapping so that the qspi area starts at 64k boundary after the hidden area
+    QMI_ATRANS0 @ $FFF and 4096 * - \ and subtract the ATRANS0 mapping so that the qspi area starts at 64k boundary after the hidden area
      constant QUADSPI_Hidden_Size
 
     \ Total QSPI size (respecting possible ATRANS0 mapping and aligning to 64k sector size)
     \ Attention: does not check the partition table if there is another partition after the current one or ATRANS Size Bits
     $400000 
-      $400D0034 @ $FFF and 4096 * \ ADTRANS0 physical address (partition mapping)
-      $FFFF + $FFFF invert and    \ align up to nearest 64k sector
+      QMI_ATRANS0 @ $FFF and 4096 * \ ATRANS0 physical address (partition mapping)
+      $FFFF + $FFFF invert and      \ align up to nearest 64k sector
     - constant QUADSPI_Size
 
   end-module> import

--- a/src/rp2350_16mib/forth/qspi.fs
+++ b/src/rp2350_16mib/forth/qspi.fs
@@ -1,4 +1,4 @@
-\ Copyright (c) 2022-2025 Travis Bemann
+\ Copyright (c) 2022-2024 Travis Bemann
 \ 
 \ Permission is hereby granted, free of charge, to any person obtaining a copy
 \ of this software and associated documentation files (the "Software"), to deal
@@ -29,12 +29,22 @@ begin-module qspi
   
     \ Quad SPI map base
     $10000000 constant QUADSPI_Map_Base
-    
-    \ Hidden QSPI size
-    $200000 constant QUADSPI_Hidden_Size
 
-    \ Total QSPI size
-    $1000000 constant QUADSPI_Size
+    $200000 constant QUADSPI_Usable_Hidden_Size
+    
+    \ Hidden QSPI size (rounded up to nearest 64k sector size if ATRANS0 mapping is used)
+    $400D0034 @ $FFF and 4096 *   \ ADTRANS0 physical address (partition mapping)
+    $FFFF + $FFFF invert and      \ align up to nearest 64k sector
+    QUADSPI_Usable_Hidden_Size +  
+    $400D0034 @ $FFF and 4096 * - \ and subtract the ATRANS0 mapping so that the qspi area starts at 64k boundary after the hidden area
+     constant QUADSPI_Hidden_Size
+
+    \ Total QSPI size (respecting possible ATRANS0 mapping and aligning to 64k sector size)
+    \ Attention: does not check the partition table if there is another partition after the current one or ATRANS Size Bits
+    $1000000 
+      $400D0034 @ $FFF and 4096 * \ ADTRANS0 physical address (partition mapping)
+      $FFFF + $FFFF invert and    \ align up to nearest 64k sector
+    - constant QUADSPI_Size
 
   end-module> import
     
@@ -55,8 +65,8 @@ begin-module qspi
   \ Get the base usable Quad SPI address
   : qspi-base ( -- addr ) QUADSPI_Map_Base QUADSPI_Hidden_Size + ;
 
-  \ Get the usable Quad SPI flash size
-  : qspi-size ( -- bytes ) QUADSPI_Size QUADSPI_Hidden_Size - ;
+  \ Get the usable Quad SPI flash size reduced by the hidden area and taking ATRANS0 (partition) mapping into account
+  : qspi-size ( -- bytes ) QUADSPI_Size QUADSPI_Usable_Hidden_Size - ;
 
   \ Bulk erase QSPI
   : erase-qspi-bulk ( -- )


### PR DESCRIPTION
I tried to create a first version of what has to be done to support RP2350 partitions.

**In this state I don't recommend merging this PR**!

At the moment I only changed the `rp2350` directory to test this functionality; other variants have to be updated when the final version is ready.

### What is working
* Flashing via UF2 Loader (at the moment with a special UF2 Loader version that supports non-contiguous blocks in the UF2)
* blocks-fs (with reduced size to align the QSPI sector addresses to the 64k boundary when partitions are used)

### What is not supported
* Adjusting the QSPI area to limit the available space to the current partition end

### What has to be considered / checked / decided
If using a PicoCalc with UF2 Loader, it is to be expected that the user changes firmwares more frequently. Therefore zeptoforth cannot assume a "good" flash state on boot up. I did not check if this is an issue with the flash dictionary.

The QSPI area can be corrupted when using it as a FAT32 FS: The flash is only prepared when the setup code runs on the first preparation of the Pico 2, and the blocks-fs is of course not included in the UF2 image created by `download_uf2_image.sh`.

Options:
* Disable QSPI blocks-fs / FAT32 and default the FS to SD-FS (what happens when there is no SD card inserted?)
* Check on every boot up if the blocks-fs is in a consistent state and reformat if needed
* Provide a runtime word to "format" the blocks-fs so the user can initialize it when it has been corrupted by other firmwares
* Include an "empty" blocks-fs in the image that is flashed via UF2 Loader — the blocks-fs would then be lost when switching firmwares
* … or something completely different

At the moment I'm inclined to disable the blocks-fs and default to SD-FS on boot up.